### PR TITLE
Check for rapidxml header during CMake's build-files generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,22 @@ link_directories(${Boost_LIBRARY_DIRS})
 add_definitions( -DBOOST_ALL_DYN_LINK )
 
 #RapidXml
+include(CheckIncludeFileCXX)
 include_directories(${RAPIDXML_INCLUDE_DIR})
+check_include_file_cxx("rapidxml.hpp" RAPIDXML_HPP_FOUND)
+IF(NOT RAPIDXML_HPP_FOUND)
+    # The rapidxml headers in Fedora's package have ".h" suffixes
+    check_include_file_cxx("rapidxml.h" RAPIDXML_H_FOUND)
+	IF(RAPIDXML_H_FOUND)
+	    # Create stub to map header from .hpp to .h
+        set(STUBS "${CMAKE_BINARY_DIR}/stubs")
+	    file(WRITE "${STUBS}/rapidxml.hpp" "#include <rapidxml.h>\n")
+		file(WRITE "${STUBS}/rapidxml_print.hpp" "#include <rapidxml_print.h>\n")
+        include_directories(${STUBS})
+	ELSE()
+        message(FATAL_ERROR "required header rapidxml.{h|hpp} not found")
+    ENDIF()
+ENDIF()
 
 # Compiler specific stuff
 IF(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,13 @@ check_include_file_cxx("rapidxml.hpp" RAPIDXML_HPP_FOUND)
 IF(NOT RAPIDXML_HPP_FOUND)
     # The rapidxml headers in Fedora's package have ".h" suffixes
     check_include_file_cxx("rapidxml.h" RAPIDXML_H_FOUND)
-	IF(RAPIDXML_H_FOUND)
-	    # Create stub to map header from .hpp to .h
+    IF(RAPIDXML_H_FOUND)
+        # Create stub to map header from .hpp to .h
         set(STUBS "${CMAKE_BINARY_DIR}/stubs")
-	    file(WRITE "${STUBS}/rapidxml.hpp" "#include <rapidxml.h>\n")
-		file(WRITE "${STUBS}/rapidxml_print.hpp" "#include <rapidxml_print.h>\n")
+        file(WRITE "${STUBS}/rapidxml.hpp" "#include <rapidxml.h>\n")
+        file(WRITE "${STUBS}/rapidxml_print.hpp" "#include <rapidxml_print.h>\n")
         include_directories(${STUBS})
-	ELSE()
+    ELSE()
         message(FATAL_ERROR "required header rapidxml.{h|hpp} not found")
     ENDIF()
 ENDIF()


### PR DESCRIPTION
If the header is not present then CMake will fail with an error
message.

Note that the rapidxml headers in Fedora's package have ".h"
extensions instead of ".hpp", so a bit of extra logic is added to
create stubs (avoids having to ifdef the source files themselves).