### PR TITLE
Fix to compile with Qt5.2.1 on Ubuntu 14.04.

### DIFF
--- a/GeneratedFiles/ui_glcapsviewer.h
+++ b/GeneratedFiles/ui_glcapsviewer.h
@@ -151,7 +151,6 @@ public:
         tabWidget->setTabShape(QTabWidget::Rounded);
         tabWidget->setDocumentMode(false);
         tabWidget->setTabsClosable(false);
-        tabWidget->setTabBarAutoHide(false);
         tabDevice = new QWidget();
         tabDevice->setObjectName(QStringLiteral("tabDevice"));
         horizontalLayout_3 = new QHBoxLayout(tabDevice);


### PR DESCRIPTION
Fixes this compile error with Qt 5.2.1 (which is the Qt version available on Ubuntu 14.04 LTS):

```
In file included from /home/joe/glCapsViewer/glCapsViewer.h:28:0,
                 from /home/joe/glCapsViewer/glCapsViewer.cpp:23:
/home/joe/glCapsViewer/GeneratedFiles/ui_glcapsviewer.h: In member function ‘void Ui_glcapsviewerClass::setupUi(QMainWindow*)’:
/home/joe/glCapsViewer/GeneratedFiles/ui_glcapsviewer.h:154:20: error: ‘class QTabWidget’ has no member named ‘setTabBarAutoHide’
         tabWidget->setTabBarAutoHide(false);
                    ^
```