### PR TITLE
Add GL_VIEWPORT_SUBPIXEL_BITS cap.

### DIFF
--- a/capslist.xml
+++ b/capslist.xml
@@ -316,6 +316,7 @@
 	<category name="GL_ARB_viewport_array">
 		<requirements extension="GL_ARB_viewport_array" version=""/>
 		<cap name="GL_MAX_VIEWPORTS" enum="0x825B" type="glint" components="1" />
+		<cap name="GL_VIEWPORT_SUBPIXEL_BITS" enum="0x825C" type="glint" components="1" />
 	</category>			
 	<category name="GL_ARB_blend_func_extended">
 		<requirements extension="GL_ARB_blend_func_extended" version=""/>


### PR DESCRIPTION
I am interested in the values of this cap across OpenGL implementations.