### PR TITLE
Added 3.2 clamp to core profile creation to allow drivers with lesser…

### DIFF
--- a/glCapsViewer.cpp
+++ b/glCapsViewer.cpp
@@ -372,6 +372,20 @@ void glCapsViewer::generateReport()
 	QApplication::restoreOverrideCursor();
 }
 
+void glCapsViewer::getCoreContextVersion(GLint &glVersionMajor, GLint &glVersionMinor)
+{
+	// Get max. supported OpenGL version for versioned core context
+	glGetIntegerv(GL_MAJOR_VERSION, &glVersionMajor);
+	glGetIntegerv(GL_MINOR_VERSION, &glVersionMinor);
+
+	// Core profiles cannot be below 3.2, clamp.
+	// Occurs on MESA RADV and OSX where compatibility level is less than 3.2
+	if(4 <= glVersionMajor) return;
+	glVersionMajor = 3;
+	if(2 <= glVersionMinor) return;
+	glVersionMinor = 2;
+}
+
 bool glCapsViewer::contextTypeSelection() 
 {
 	// Get available context types
@@ -430,10 +444,10 @@ bool glCapsViewer::contextTypeSelection()
 			if (item == "OpenGL core context") {
 				glewExperimental = GL_TRUE;
 				GLenum err = glewInit();
-				// Get max. supported OpenGL version for versioned core context
+
 				GLint glVersionMajor, glVersionMinor;
-				glGetIntegerv(GL_MAJOR_VERSION, &glVersionMajor);
-				glGetIntegerv(GL_MINOR_VERSION, &glVersionMinor);
+				getCoreContextVersion(glVersionMajor, glVersionMinor);
+
 				// Create core context
 				glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, glVersionMajor);
 				glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, glVersionMinor);
@@ -485,10 +499,10 @@ void glCapsViewer::slotRefreshReport()
 			if (item == "OpenGL core context") {
 				glewExperimental = GL_TRUE;
 				GLenum err = glewInit();
-				// Get max. supported OpenGL version for versioned core context
+
 				GLint glVersionMajor, glVersionMinor;
-				glGetIntegerv(GL_MAJOR_VERSION, &glVersionMajor);
-				glGetIntegerv(GL_MINOR_VERSION, &glVersionMinor);
+				getCoreContextVersion(glVersionMajor, glVersionMinor);
+
 				// Create core context
 				glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, glVersionMajor);
 				glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, glVersionMinor);

--- a/glCapsViewer.h
+++ b/glCapsViewer.h
@@ -61,6 +61,7 @@ private:
 	void displayExtensions();
 	void displayCompressedFormats();
 	void displayInternalFormatInfo();
+	void getCoreContextVersion(GLint &glVersionMajor, GLint &glVersionMinor);
 private slots:
 	void slotRefreshReport();
 	void slotClose();


### PR DESCRIPTION
… compatibility profile to create core profiles.

This isolate the Major/Minor GL version generation for core context creation and clamps it to at least 3.2.
Fixes issues using the MESA RADV drivers where the comp context is at 3.0 and causes core contexts to fail because the values are too low.

Opens the option to also use the GLX_MESA_query_renderer to query the actual max Core context in a single place in the code.