### PR TITLE
Fix build on MacOS & some small cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ find_package(OpenGL REQUIRED)
 #Glew
 find_package(GLEW REQUIRED)
 include_directories(${GLEW_INCLUDE_DIR})
-link_directories(${GLEW_LIBRARIES})
 
 #Glfw
 find_path(GLFW_INCLUDE_DIR GLFW/glfw3.h)
@@ -77,7 +76,7 @@ target_link_libraries(${NAME} Qt5::Core)
 target_link_libraries(${NAME} Qt5::Gui)	
 target_link_libraries(${NAME} Qt5::Network)	
 target_link_libraries(${NAME} Qt5::Widgets)
-target_link_libraries(${NAME} ${GLEW_LIBRARIES})
+target_link_libraries(${NAME} GLEW::GLEW)
 target_link_libraries(${NAME} ${OPENGL_LIBRARIES})
 target_link_libraries(${NAME} glfw ${GLFW_LIBRARY})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,5 +78,5 @@ target_link_libraries(${NAME} Qt5::Network)
 target_link_libraries(${NAME} Qt5::Widgets)
 target_link_libraries(${NAME} GLEW::GLEW)
 target_link_libraries(${NAME} ${OPENGL_LIBRARIES})
-target_link_libraries(${NAME} glfw ${GLFW_LIBRARY})
+target_link_libraries(${NAME} ${GLFW_LIBRARY})
 

--- a/glCapsViewer.cpp
+++ b/glCapsViewer.cpp
@@ -442,6 +442,9 @@ bool glCapsViewer::contextTypeSelection()
 		}
 	}
 #endif
+#ifdef __APPLE__
+	core.availableContextTypes.push_back("OpenGL core context");
+#endif
 	core.contextType = "default";
 	if (core.availableContextTypes.size() > 1) {
 		QStringList items;
@@ -460,6 +463,10 @@ bool glCapsViewer::contextTypeSelection()
 				GLint glVersionMajor, glVersionMinor;
 				glGetIntegerv(GL_MAJOR_VERSION, &glVersionMajor);
 				glGetIntegerv(GL_MINOR_VERSION, &glVersionMinor);
+#if __APPLE__
+				glVersionMajor = 4;
+				glVersionMinor = 1;
+#endif
 				// Create core context
 				glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, glVersionMajor);
 				glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, glVersionMinor);

--- a/glCapsViewerCore.cpp
+++ b/glCapsViewerCore.cpp
@@ -156,23 +156,27 @@ string glCapsViewerCore::readOperatingSystem()
 		osinfo << osname.sysname << " " << osname.release << " (" << osname.machine << ")";
 		return osinfo.str();
 	#endif
-	// TODO : MacOSX
+	#ifdef __APPLE__
+	return "MacOS";
+	#endif
 }
 
 void glCapsViewerCore::readExtensions()
 {
 	// Use glGetStringi if available (GL 3.x)
-	if ((GL_VERSION_3_0) && (glGetStringi != NULL)) {
+	if ((GL_VERSION_3_0) && (glGetStringi != NULL) && contextType == "core") {
 		GLint numExtensions;
 		glGetIntegerv(GL_NUM_EXTENSIONS, &numExtensions);
 		for (int i = 0; i < numExtensions; i++) {
 			const GLubyte* glExt = glGetStringi(GL_EXTENSIONS, i);
+			assert(glExt);
 			string ext = reinterpret_cast<const char*>(glExt);
 			extensions.push_back(ext);
 		}
 	}
 	else {
 		const GLubyte* glExtensions = glGetString(GL_EXTENSIONS);
+		assert(glExtensions);
 		string extensionString = reinterpret_cast<const char*>(glExtensions);
 		split(extensionString, extensions, ' ');
 	}


### PR DESCRIPTION
I was surprised to find no MacOS reports on opengl.gpuinfo.org. Fixing the build was not too bad, I had to implement some hacks because of Apple's baffling decision to strictly require core profile to do 3.x calls (and conversely, removing the ability to glGetString(GL_EXTENSIONS) in legacy mode). Since Apple is unlikely to ever implement anything beyond 4.1, this should be fine.

I had to also touch up the CMakeFiles to account for changes in the FindGLEW module, and make sure to not link with `glfw` when the target is named something else. I might do another pass on the CMakeFiles to modernize them later.